### PR TITLE
Add basic XOR cipher example

### DIFF
--- a/contrib/entry_level_cipher.py
+++ b/contrib/entry_level_cipher.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""
+Simple XOR cipher example.
+This demonstration script is not secure and is for educational purposes only.
+"""
+
+import sys
+
+
+def xor_encrypt(data: bytes, key: bytes) -> bytes:
+    key_len = len(key)
+    return bytes([data[i] ^ key[i % key_len] for i in range(len(data))])
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <text> <key>")
+        sys.exit(1)
+    text, key = sys.argv[1].encode(), sys.argv[2].encode()
+    encrypted = xor_encrypt(text, key)
+    print(encrypted.hex())


### PR DESCRIPTION
## Summary
- add a tiny XOR cipher demo in `contrib`

## Testing
- `python3 contrib/entry_level_cipher.py test key`

------
https://chatgpt.com/codex/tasks/task_e_685c51584e84832181a16ff03614cbea